### PR TITLE
Add x509.ExtKeyUsageClientAuth to CA ExtKeyUsage

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -71,7 +71,7 @@ func main() {
 		NotBefore:             notBefore,
 		NotAfter:              notAfter,
 		KeyUsage:              x509.KeyUsageCertSign,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
 		IsCA: true,
 	}


### PR DESCRIPTION
Otherwise, Client certificates won't work with this CA

Clone of https://github.com/Shyp/generate-tls-cert/pull/1